### PR TITLE
Fix quote bug in terminal command

### DIFF
--- a/autoload/vim_oracle.vim
+++ b/autoload/vim_oracle.vim
@@ -68,9 +68,11 @@ function! vim_oracle#open_positioned_terminal(command) abort
   execute open_cmd
 
   if has('nvim')
-    call termopen(a:command)
+    " Use the configured shell to run {command} so that quoting with spaces or
+    " single quotes works consistently.
+    call termopen([&shell, &shellcmdflag, a:command])
   else
-    call term_start(a:command, {'curwin': 1})
+    call term_start([&shell, &shellcmdflag, a:command], {'curwin': 1})
   endif
   startinsert
 endfunction
@@ -98,6 +100,8 @@ function! vim_oracle#open_floating_terminal(command) abort
   
   let buf = nvim_create_buf(v:false, v:true)
   let win = nvim_open_win(buf, v:true, opts)
-  call termopen(a:command)
+  " Run the command through the user's shell so that prompts containing quotes
+  " or spaces are handled correctly.
+  call termopen([&shell, &shellcmdflag, a:command])
   startinsert
 endfunction

--- a/autoload/vim_oracle.vim
+++ b/autoload/vim_oracle.vim
@@ -53,16 +53,26 @@ function! vim_oracle#execute_command(prompt) abort
 endfunction
 
 function! vim_oracle#open_positioned_terminal(command) abort
+  " Map the configured window position to commands that open a new window
+  " before running the terminal command.  This avoids quoting problems when
+  " {command} contains single quotes.
   let position_map = {
-    \ 'below': 'botright',
-    \ 'above': 'topleft',
-    \ 'right': 'botright vertical',
-    \ 'left': 'topleft vertical',
-    \ 'tab': 'tabnew |'
-    \ }
-  
-  let position = get(position_map, g:vim_oracle_window_position, 'botright')
-  execute position . ' term ' . a:command
+        \ 'below': 'botright new',
+        \ 'above': 'topleft new',
+        \ 'right': 'botright vertical new',
+        \ 'left': 'topleft vertical new',
+        \ 'tab': 'tabnew'
+        \ }
+
+  let open_cmd = get(position_map, g:vim_oracle_window_position, 'botright new')
+  execute open_cmd
+
+  if has('nvim')
+    call termopen(a:command)
+  else
+    call term_start(a:command, {'curwin': 1})
+  endif
+  startinsert
 endfunction
 
 function! vim_oracle#open_floating_terminal(command) abort


### PR DESCRIPTION
## Summary
- avoid quoting issues when prompts contain single quotes
- use `termopen`/`term_start` inside `open_positioned_terminal`

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_684b2dc778708329baa13b362f6ac4a8