### PR TITLE
Add editable prompt window mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ let g:vim_oracle_window_position = 'floating'
 Run `:VimOracle` (or your mapping) to open an interactive prompt. The prompt will be pre-filled with context about your current file and line number.
 You can also open a dedicated prompt window with `:VimOraclePromptWindow`. Edit
 the text in that window and use `:VimOracleSend` (or your mapping) to send
-it to the AI tool.
+it to the AI tool. The prompt window uses the `vimoracleprompt` filetype so you
+can define autocmds or mappings specific to it.
 
 ### Direct Commands
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ git clone https://github.com/your-username/vim-oracle ~/.vim/bundle/vim-oracle
 
 1. Install the plugin using your preferred method
 2. Make sure you have an AI command-line tool installed (e.g., `codex`, `chatgpt`, etc.)
-3. Use `<Leader>ai` to open the AI prompt, or `:VimOracle`
+3. Run `:VimOracle` (or your custom mapping) to open the AI prompt
 
 ## Configuration
 
@@ -76,18 +76,13 @@ let g:vim_oracle_filetype_prompts = {
 \ 'vim': 'I need help with this Vim script in {filename} at line {line}. '
 \ }
 
-" Disable default key mapping if you want to create your own
-let g:vim_oracle_no_mappings = 1
 ```
 
 ### Custom Key Mappings
 
-If you disable the default mappings, you can create your own:
+Define your own mappings to trigger the plugin:
 
 ```vim
-let g:vim_oracle_no_mappings = 1
-
-" Custom mappings
 nnoremap <Leader>ask :VimOracle<CR>
 nnoremap <Leader>explain :VimOraclePrompt Explain this code<CR>
 nnoremap <Leader>fix :VimOraclePrompt How can I fix this?<CR>
@@ -115,9 +110,9 @@ let g:vim_oracle_window_position = 'floating'
 
 ### Interactive Mode
 
-Use `<Leader>ai` (or `:VimOracle`) to open an interactive prompt. The prompt will be pre-filled with context about your current file and line number.
+Run `:VimOracle` (or your mapping) to open an interactive prompt. The prompt will be pre-filled with context about your current file and line number.
 You can also open a dedicated prompt window with `:VimOraclePromptWindow`. Edit
-the text in that window and press `<Leader>ai` or run `:VimOracleSend` to send
+the text in that window and use `:VimOracleSend` (or your mapping) to send
 it to the AI tool.
 
 ### Direct Commands
@@ -170,7 +165,6 @@ let g:vim_oracle_filetype_prompts = {
 \ }
 
 " Custom key mappings
-let g:vim_oracle_no_mappings = 1
 nnoremap <Leader>ai :VimOracle<CR>
 nnoremap <Leader>explain :VimOraclePrompt Explain this code<CR>
 ```
@@ -189,10 +183,6 @@ You can use these placeholders in your prompt templates:
 - `:VimOraclePrompt {text}` - Send direct prompt to AI tool
 - `:VimOraclePromptWindow` - Open a scratch buffer for editing a prompt
 - `:VimOracleSend` - Send the contents of the current prompt window
-
-## Default Mappings
-
-- `<Leader>ai` - Open interactive AI prompt (can be disabled with `g:vim_oracle_no_mappings`)
 
 ## Help
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ let g:vim_oracle_window_position = 'floating'
 ### Interactive Mode
 
 Use `<Leader>ai` (or `:VimOracle`) to open an interactive prompt. The prompt will be pre-filled with context about your current file and line number.
+You can also open a dedicated prompt window with `:VimOraclePromptWindow`. Edit
+the text in that window and press `<Leader>ai` or run `:VimOracleSend` to send
+it to the AI tool.
 
 ### Direct Commands
 
@@ -182,8 +185,10 @@ You can use these placeholders in your prompt templates:
 
 ## Commands
 
-- `:VimOracle` - Open interactive AI prompt
+- `:VimOracle` - Open interactive AI prompt or send current prompt window
 - `:VimOraclePrompt {text}` - Send direct prompt to AI tool
+- `:VimOraclePromptWindow` - Open a scratch buffer for editing a prompt
+- `:VimOracleSend` - Send the contents of the current prompt window
 
 ## Default Mappings
 

--- a/README.md
+++ b/README.md
@@ -111,10 +111,13 @@ let g:vim_oracle_window_position = 'floating'
 ### Interactive Mode
 
 Run `:VimOracle` (or your mapping) to open an interactive prompt. The prompt will be pre-filled with context about your current file and line number.
-You can also open a dedicated prompt window with `:VimOraclePromptWindow`. Edit
-the text in that window and use `:VimOracleSend` (or your mapping) to send
-it to the AI tool. The prompt window uses the `vimoracleprompt` filetype so you
-can define autocmds or mappings specific to it.
+You can also open a dedicated prompt window with `:VimOraclePromptWindow`. If
+you run this command while text is visually selected, the selected text will be
+inserted into the prompt window. Otherwise, the window is populated with the
+default prompt for the current filetype. Edit the text and use
+`:VimOracleSend` (or your mapping) to send it to the AI tool. The prompt window
+uses the `vimoracleprompt` filetype so you can define autocmds or mappings
+specific to it.
 
 ### Direct Commands
 
@@ -182,7 +185,9 @@ You can use these placeholders in your prompt templates:
 
 - `:VimOracle` - Open interactive AI prompt or send current prompt window
 - `:VimOraclePrompt {text}` - Send direct prompt to AI tool
-- `:VimOraclePromptWindow` - Open a scratch buffer for editing a prompt
+- `:VimOraclePromptWindow` - Open a scratch buffer for editing a prompt. If text
+  is visually selected when the command is run, that text pre-fills the window
+  instead of the default prompt
 - `:VimOracleSend` - Send the contents of the current prompt window
 
 ## Help

--- a/autoload/vim_oracle.vim
+++ b/autoload/vim_oracle.vim
@@ -129,8 +129,9 @@ function! vim_oracle#open_prompt_window() abort
   resize 5
   setlocal buftype=nofile bufhidden=wipe noswapfile nobuflisted
   let b:vim_oracle_prompt_window = 1
-  call setline(1, default_prompt)
-  normal! G
+  call setline(1, split(default_prompt, "\n"))
+  normal! G$
+  startinsert
 endfunction
 
 " Send the contents of the current prompt buffer to the AI tool and close it

--- a/autoload/vim_oracle.vim
+++ b/autoload/vim_oracle.vim
@@ -128,6 +128,7 @@ function! vim_oracle#open_prompt_window() abort
   botright new
   resize 5
   setlocal buftype=nofile bufhidden=wipe noswapfile nobuflisted
+  setlocal filetype=vimoracleprompt
   let b:vim_oracle_prompt_window = 1
   call setline(1, split(default_prompt, "\n"))
   normal! G$

--- a/autoload/vim_oracle.vim
+++ b/autoload/vim_oracle.vim
@@ -118,19 +118,34 @@ endfunction
 
 " Open a small scratch buffer pre-populated with the default prompt
 function! vim_oracle#open_prompt_window() abort
-  let filename = expand('%')
-  let linenum = line('.')
-  let filetype = &filetype
+  let l:prompt = ''
+  if line("'<") > 0 && line("'>") > 0
+    let l:start = getpos("'<")
+    let l:end = getpos("'>")
+    let l:lines = getline(l:start[1], l:end[1])
+    if len(l:lines) == 1
+      let l:lines[0] = l:lines[0][l:start[2]-1:l:end[2]-1]
+    else
+      let l:lines[0] = l:lines[0][l:start[2]-1:]
+      let l:lines[-1] = l:lines[-1][:l:end[2]-1]
+    endif
+    let l:prompt = join(l:lines, "\n")
+  endif
 
-  let template = vim_oracle#get_prompt_template(filetype)
-  let default_prompt = vim_oracle#format_prompt(template, filename, linenum)
+  if empty(l:prompt)
+    let l:filename = expand('%')
+    let l:linenum = line('.')
+    let l:filetype = &filetype
+    let l:template = vim_oracle#get_prompt_template(l:filetype)
+    let l:prompt = vim_oracle#format_prompt(l:template, l:filename, l:linenum)
+  endif
 
   botright new
   resize 5
   setlocal buftype=nofile bufhidden=wipe noswapfile nobuflisted
   setlocal filetype=vimoracleprompt
   let b:vim_oracle_prompt_window = 1
-  call setline(1, split(default_prompt, "\n"))
+  call setline(1, split(l:prompt, "\n"))
   normal! G$
   startinsert!
 endfunction

--- a/autoload/vim_oracle.vim
+++ b/autoload/vim_oracle.vim
@@ -132,7 +132,7 @@ function! vim_oracle#open_prompt_window() abort
   let b:vim_oracle_prompt_window = 1
   call setline(1, split(default_prompt, "\n"))
   normal! G$
-  startinsert
+  startinsert!
 endfunction
 
 " Send the contents of the current prompt buffer to the AI tool and close it

--- a/doc/tags
+++ b/doc/tags
@@ -1,10 +1,11 @@
 :VimOracle	vim-oracle.txt	/*:VimOracle*
 :VimOraclePrompt	vim-oracle.txt	/*:VimOraclePrompt*
+:VimOraclePromptWindow	vim-oracle.txt	/*:VimOraclePromptWindow*
+:VimOracleSend	vim-oracle.txt	/*:VimOracleSend*
 <Leader>ai	vim-oracle.txt	/*<Leader>ai*
 g:vim_oracle_command	vim-oracle.txt	/*g:vim_oracle_command*
 g:vim_oracle_default_prompt	vim-oracle.txt	/*g:vim_oracle_default_prompt*
 g:vim_oracle_filetype_prompts	vim-oracle.txt	/*g:vim_oracle_filetype_prompts*
-g:vim_oracle_no_mappings	vim-oracle.txt	/*g:vim_oracle_no_mappings*
 g:vim_oracle_window_position	vim-oracle.txt	/*g:vim_oracle_window_position*
 vim-oracle-commands	vim-oracle.txt	/*vim-oracle-commands*
 vim-oracle-configuration	vim-oracle.txt	/*vim-oracle-configuration*

--- a/doc/tags
+++ b/doc/tags
@@ -15,3 +15,4 @@ vim-oracle-installation	vim-oracle.txt	/*vim-oracle-installation*
 vim-oracle-introduction	vim-oracle.txt	/*vim-oracle-introduction*
 vim-oracle-mappings	vim-oracle.txt	/*vim-oracle-mappings*
 vim-oracle.txt	vim-oracle.txt	/*vim-oracle.txt*
+vimoracleprompt-filetype	vim-oracle.txt	/*vimoracleprompt-filetype*

--- a/doc/vim-oracle.txt
+++ b/doc/vim-oracle.txt
@@ -117,17 +117,29 @@ g:vim_oracle_window_position~
 :VimOraclePrompt {text}
     Directly sends a prompt to the AI tool. The {text} will be appended to
     the context prompt for the current file and line.
-    
+
     Example: >
         :VimOraclePrompt Explain this function
 <
+
+                                                                *:VimOraclePromptWindow*
+:VimOraclePromptWindow
+    Opens a small buffer pre-populated with the default prompt for the current
+    filetype. Edit the text and use |:VimOracleSend| or <Leader>ai to send it.
+
+                                                                     *:VimOracleSend*
+:VimOracleSend
+    Sends the contents of the current prompt buffer to the AI tool and closes
+    the buffer. If executed outside a prompt buffer, it behaves like
+    |:VimOracle|.
 
 ==============================================================================
 5. MAPPINGS                                                 *vim-oracle-mappings*
 
 <Leader>ai                                                        *<Leader>ai*
     Normal mode mapping that calls |:VimOracle|. This mapping can be disabled
-    by setting |g:vim_oracle_no_mappings| to 1.
+    by setting |g:vim_oracle_no_mappings| to 1. When used inside a prompt
+    buffer it sends the prompt to the AI and closes the buffer.
 
 ==============================================================================
 6. EXAMPLES                                                 *vim-oracle-examples*

--- a/doc/vim-oracle.txt
+++ b/doc/vim-oracle.txt
@@ -117,13 +117,19 @@ g:vim_oracle_window_position~
 :VimOraclePromptWindow
     Opens a small buffer pre-populated with the default prompt for the current
     filetype. Edit the text and use |:VimOracleSend| (or your mapping) to send
-    it.
+    it. The buffer uses the |vimoracleprompt-filetype| filetype so you can set
+    autocmds or mappings specific to the prompt window.
 
                                                                      *:VimOracleSend*
 :VimOracleSend
     Sends the contents of the current prompt buffer to the AI tool and closes
     the buffer. If executed outside a prompt buffer, it behaves like
     |:VimOracle|.
+
+vimoracleprompt-filetype                              *vimoracleprompt-filetype*
+    Filetype used for the prompt window opened by |:VimOraclePromptWindow|.
+    Define autocmds or mappings for this filetype to customize the prompt
+    buffer.
 
 ==============================================================================
 5. MAPPINGS                                                 *vim-oracle-mappings*

--- a/doc/vim-oracle.txt
+++ b/doc/vim-oracle.txt
@@ -78,15 +78,6 @@ g:vim_oracle_filetype_prompts~
         \ }
 <
 
-                                                      *g:vim_oracle_no_mappings*
-g:vim_oracle_no_mappings~
-    Default: 0
-    
-    Set to 1 to disable the default key mapping (<Leader>ai).
-    
-    Example: >
-        let g:vim_oracle_no_mappings = 1
-<
 
                                                   *g:vim_oracle_window_position*
 g:vim_oracle_window_position~
@@ -125,7 +116,8 @@ g:vim_oracle_window_position~
                                                                 *:VimOraclePromptWindow*
 :VimOraclePromptWindow
     Opens a small buffer pre-populated with the default prompt for the current
-    filetype. Edit the text and use |:VimOracleSend| or <Leader>ai to send it.
+    filetype. Edit the text and use |:VimOracleSend| (or your mapping) to send
+    it.
 
                                                                      *:VimOracleSend*
 :VimOracleSend
@@ -137,9 +129,8 @@ g:vim_oracle_window_position~
 5. MAPPINGS                                                 *vim-oracle-mappings*
 
 <Leader>ai                                                        *<Leader>ai*
-    Normal mode mapping that calls |:VimOracle|. This mapping can be disabled
-    by setting |g:vim_oracle_no_mappings| to 1. When used inside a prompt
-    buffer it sends the prompt to the AI and closes the buffer.
+    Example mapping you can define to call |:VimOracle|. When used inside a
+    prompt buffer it sends the prompt to the AI and closes the buffer.
 
 ==============================================================================
 6. EXAMPLES                                                 *vim-oracle-examples*
@@ -160,8 +151,7 @@ Advanced configuration with filetype-specific prompts: >
     \ }
 <
 
-Disable default mappings and create custom ones: >
-    let g:vim_oracle_no_mappings = 1
+Define your own mappings: >
     nnoremap <Leader>ask :VimOracle<CR>
     nnoremap <Leader>explain :VimOraclePrompt Explain this code<CR>
 <

--- a/doc/vim-oracle.txt
+++ b/doc/vim-oracle.txt
@@ -115,10 +115,12 @@ g:vim_oracle_window_position~
 
                                                                 *:VimOraclePromptWindow*
 :VimOraclePromptWindow
-    Opens a small buffer pre-populated with the default prompt for the current
-    filetype. Edit the text and use |:VimOracleSend| (or your mapping) to send
-    it. The buffer uses the |vimoracleprompt-filetype| filetype so you can set
-    autocmds or mappings specific to the prompt window.
+    Opens a small buffer for editing a prompt. If text is visually selected
+    when you run the command, that text is inserted into the window instead of
+    the default prompt. Otherwise the window is pre-populated with the default
+    prompt for the current filetype. Edit the text and use |:VimOracleSend| (or
+    your mapping) to send it. The buffer uses the |vimoracleprompt-filetype|
+    filetype so you can set autocmds or mappings specific to the prompt window.
 
                                                                      *:VimOracleSend*
 :VimOracleSend

--- a/plugin/vim-oracle.vim
+++ b/plugin/vim-oracle.vim
@@ -27,7 +27,3 @@ command! -nargs=0 VimOracle call vim_oracle#invoke()
 command! -nargs=1 VimOraclePrompt call vim_oracle#prompt_with_text(<q-args>)
 command! -nargs=0 VimOraclePromptWindow call vim_oracle#open_prompt_window()
 command! -nargs=0 VimOracleSend call vim_oracle#send_prompt_buffer()
-
-if !exists('g:vim_oracle_no_mappings') || !g:vim_oracle_no_mappings
-  nnoremap <Leader>ai :VimOracle<CR>
-endif

--- a/plugin/vim-oracle.vim
+++ b/plugin/vim-oracle.vim
@@ -23,8 +23,10 @@ if !exists('g:vim_oracle_window_position')
   let g:vim_oracle_window_position = 'below'
 endif
 
-command! -nargs=0 VimOracle call vim_oracle#prompt()
+command! -nargs=0 VimOracle call vim_oracle#invoke()
 command! -nargs=1 VimOraclePrompt call vim_oracle#prompt_with_text(<q-args>)
+command! -nargs=0 VimOraclePromptWindow call vim_oracle#open_prompt_window()
+command! -nargs=0 VimOracleSend call vim_oracle#send_prompt_buffer()
 
 if !exists('g:vim_oracle_no_mappings') || !g:vim_oracle_no_mappings
   nnoremap <Leader>ai :VimOracle<CR>


### PR DESCRIPTION
## Summary
- add wrapper command `VimOracle` that either opens the prompt or sends a prompt buffer
- implement prompt window workflow in autoload functions
- expose new commands `VimOraclePromptWindow` and `VimOracleSend`
- document new behavior in README and help file

## Testing
- `vim -Nu NONE -n -es -c 'source plugin/vim-oracle.vim' -c 'quit'`


------
https://chatgpt.com/codex/tasks/task_e_684b8e221f9c8329b7dc41d279b45a41