### PR TITLE
Fix custom filetype event for VimOracle prompt window

### DIFF
--- a/autoload/vim_oracle.vim
+++ b/autoload/vim_oracle.vim
@@ -143,7 +143,8 @@ function! vim_oracle#open_prompt_window() abort
   botright new
   resize 5
   setlocal buftype=nofile bufhidden=wipe noswapfile nobuflisted
-  setlocal filetype=vimoracleprompt
+  " Use :setfiletype so the FileType event triggers for user autocmds
+  execute 'setfiletype vimoracleprompt'
   let b:vim_oracle_prompt_window = 1
   call setline(1, split(l:prompt, "\n"))
   normal! G$


### PR DESCRIPTION
## Summary
- use `setfiletype` to assign prompt window filetype

## Testing
- `vim -Nu NONE -n -es -S /tmp/test_ft_event.vim > /tmp/vim.log 2>&1`
- `cat /tmp/ft_result2`
- `cat /tmp/ft_autocmd`


------
https://chatgpt.com/codex/tasks/task_e_684c2b1412b08329a4991d6969f13cbe