### PR TITLE
Update VimOraclePromptWindow to use active visual selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,12 +112,12 @@ let g:vim_oracle_window_position = 'floating'
 
 Run `:VimOracle` (or your mapping) to open an interactive prompt. The prompt will be pre-filled with context about your current file and line number.
 You can also open a dedicated prompt window with `:VimOraclePromptWindow`. If
-you run this command from Visual mode, the selected text will be
-inserted into the prompt window. Otherwise, the window is populated with the
-default prompt for the current filetype. Edit the text and use
-`:VimOracleSend` (or your mapping) to send it to the AI tool. The prompt window
-uses the `vimoracleprompt` filetype so you can define autocmds or mappings
-specific to it.
+you run this command from Visual mode, the selected text will be inserted into
+the prompt window and the cursor is placed in Insert mode on a new blank line
+below it. Otherwise, the window is populated with the default prompt for the
+current filetype. Edit the text and use `:VimOracleSend` (or your mapping) to
+send it to the AI tool. The prompt window uses the `vimoracleprompt` filetype so
+you can define autocmds or mappings specific to it.
 
 ### Direct Commands
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ let g:vim_oracle_window_position = 'floating'
 
 Run `:VimOracle` (or your mapping) to open an interactive prompt. The prompt will be pre-filled with context about your current file and line number.
 You can also open a dedicated prompt window with `:VimOraclePromptWindow`. If
-you run this command while text is visually selected, the selected text will be
+you run this command from Visual mode, the selected text will be
 inserted into the prompt window. Otherwise, the window is populated with the
 default prompt for the current filetype. Edit the text and use
 `:VimOracleSend` (or your mapping) to send it to the AI tool. The prompt window

--- a/autoload/vim_oracle.vim
+++ b/autoload/vim_oracle.vim
@@ -118,19 +118,23 @@ endfunction
 
 " Open a small scratch buffer pre-populated with either the default prompt
 " or the user's visual selection when invoked from Visual mode
-function! vim_oracle#open_prompt_window(vismode) abort
+function! vim_oracle#open_prompt_window(firstline, lastline, vismode) range abort
   let l:prompt = ''
-  if a:vismode !=# '' && line("'<") > 0 && line("'>") > 0
-    let l:start = getpos("'<")
-    let l:end = getpos("'>")
-    let l:lines = getline(l:start[1], l:end[1])
-    if len(l:lines) == 1
-      let l:lines[0] = l:lines[0][l:start[2]-1:l:end[2]-1]
+  if a:vismode !=# '' && a:firstline > 0 && a:lastline > 0 && a:lastline >= a:firstline
+    if a:vismode ==# 'v' || a:vismode ==# "\<C-v>"
+      let l:start = getpos("'<")
+      let l:end = getpos("'>")
+      let l:lines = getline(l:start[1], l:end[1])
+      if len(l:lines) == 1
+        let l:lines[0] = l:lines[0][l:start[2]-1:l:end[2]-1]
+      else
+        let l:lines[0] = l:lines[0][l:start[2]-1:]
+        let l:lines[-1] = l:lines[-1][:l:end[2]-1]
+      endif
+      let l:prompt = join(l:lines, "\n")
     else
-      let l:lines[0] = l:lines[0][l:start[2]-1:]
-      let l:lines[-1] = l:lines[-1][:l:end[2]-1]
+      let l:prompt = join(getline(a:firstline, a:lastline), "\n")
     endif
-    let l:prompt = join(l:lines, "\n")
   endif
 
   if empty(l:prompt)

--- a/autoload/vim_oracle.vim
+++ b/autoload/vim_oracle.vim
@@ -118,7 +118,7 @@ endfunction
 
 " Open a small scratch buffer pre-populated with either the default prompt
 " or the user's visual selection when invoked from Visual mode
-function! vim_oracle#open_prompt_window(firstline, lastline, vismode) range abort
+function! vim_oracle#open_prompt_window(vismode) range abort
   let l:prompt = ''
   if a:vismode !=# '' && a:firstline > 0 && a:lastline > 0 && a:lastline >= a:firstline
     if a:vismode ==# 'v' || a:vismode ==# "\<C-v>"

--- a/autoload/vim_oracle.vim
+++ b/autoload/vim_oracle.vim
@@ -117,7 +117,8 @@ function! vim_oracle#invoke() abort
 endfunction
 
 " Open a small scratch buffer pre-populated with the default prompt
-function! vim_oracle#open_prompt_window(firstline, lastline, vismode) abort range
+" The range attribute must appear before abort for older Vim versions
+function! vim_oracle#open_prompt_window(firstline, lastline, vismode) range abort
   let l:prompt = ''
   if a:vismode !=# '' && line("'<") > 0 && line("'>") > 0
     let l:start = getpos("'<")

--- a/autoload/vim_oracle.vim
+++ b/autoload/vim_oracle.vim
@@ -119,7 +119,7 @@ endfunction
 " Open a small scratch buffer pre-populated with the default prompt
 function! vim_oracle#open_prompt_window() abort
   let l:prompt = ''
-  if line("'<") > 0 && line("'>") > 0
+  if index(['v', 'V', "\<C-v>"], mode()) != -1
     let l:start = getpos("'<")
     let l:end = getpos("'>")
     let l:lines = getline(l:start[1], l:end[1])
@@ -146,7 +146,8 @@ function! vim_oracle#open_prompt_window() abort
   setlocal filetype=vimoracleprompt
   let b:vim_oracle_prompt_window = 1
   call setline(1, split(l:prompt, "\n"))
-  normal! G$
+  call append('$', '')
+  normal! G
   startinsert!
 endfunction
 

--- a/autoload/vim_oracle.vim
+++ b/autoload/vim_oracle.vim
@@ -117,9 +117,9 @@ function! vim_oracle#invoke() abort
 endfunction
 
 " Open a small scratch buffer pre-populated with the default prompt
-function! vim_oracle#open_prompt_window() abort
+function! vim_oracle#open_prompt_window(firstline, lastline, vismode) abort range
   let l:prompt = ''
-  if index(['v', 'V', "\<C-v>"], mode()) != -1
+  if a:vismode !=# '' && line("'<") > 0 && line("'>") > 0
     let l:start = getpos("'<")
     let l:end = getpos("'>")
     let l:lines = getline(l:start[1], l:end[1])

--- a/autoload/vim_oracle.vim
+++ b/autoload/vim_oracle.vim
@@ -116,9 +116,9 @@ function! vim_oracle#invoke() abort
   endif
 endfunction
 
-" Open a small scratch buffer pre-populated with the default prompt
-" The range attribute must appear before abort for older Vim versions
-function! vim_oracle#open_prompt_window(firstline, lastline, vismode) range abort
+" Open a small scratch buffer pre-populated with either the default prompt
+" or the user's visual selection when invoked from Visual mode
+function! vim_oracle#open_prompt_window(vismode) abort
   let l:prompt = ''
   if a:vismode !=# '' && line("'<") > 0 && line("'>") > 0
     let l:start = getpos("'<")

--- a/doc/vim-oracle.txt
+++ b/doc/vim-oracle.txt
@@ -116,11 +116,12 @@ g:vim_oracle_window_position~
                                                                 *:VimOraclePromptWindow*
 :VimOraclePromptWindow
     Opens a small buffer for editing a prompt. If the command is executed from
-    Visual mode, the selected text is inserted into the window instead of the
-    default prompt. Otherwise the window is pre-populated with the default
-    prompt for the current filetype. Edit the text and use |:VimOracleSend| (or
-    your mapping) to send it. The buffer uses the |vimoracleprompt-filetype|
-    filetype so you can set autocmds or mappings specific to the prompt window.
+    Visual mode, the selected text is inserted into the window and the cursor is
+    left in Insert mode on a new blank line below it. Otherwise the window is
+    pre-populated with the default prompt for the current filetype. Edit the
+    text and use |:VimOracleSend| (or your mapping) to send it. The buffer uses
+    the |vimoracleprompt-filetype| filetype so you can set autocmds or mappings
+    specific to the prompt window.
 
                                                                      *:VimOracleSend*
 :VimOracleSend

--- a/doc/vim-oracle.txt
+++ b/doc/vim-oracle.txt
@@ -115,9 +115,9 @@ g:vim_oracle_window_position~
 
                                                                 *:VimOraclePromptWindow*
 :VimOraclePromptWindow
-    Opens a small buffer for editing a prompt. If text is visually selected
-    when you run the command, that text is inserted into the window instead of
-    the default prompt. Otherwise the window is pre-populated with the default
+    Opens a small buffer for editing a prompt. If the command is executed from
+    Visual mode, the selected text is inserted into the window instead of the
+    default prompt. Otherwise the window is pre-populated with the default
     prompt for the current filetype. Edit the text and use |:VimOracleSend| (or
     your mapping) to send it. The buffer uses the |vimoracleprompt-filetype|
     filetype so you can set autocmds or mappings specific to the prompt window.

--- a/plugin/vim-oracle.vim
+++ b/plugin/vim-oracle.vim
@@ -26,5 +26,5 @@ endif
 command! -nargs=0 VimOracle call vim_oracle#invoke()
 command! -nargs=1 VimOraclePrompt call vim_oracle#prompt_with_text(<q-args>)
 command! -nargs=0 -range VimOraclePromptWindow \
-            call vim_oracle#open_prompt_window(<line1>, <line2>, visualmode())
+            call vim_oracle#open_prompt_window(visualmode())
 command! -nargs=0 VimOracleSend call vim_oracle#send_prompt_buffer()

--- a/plugin/vim-oracle.vim
+++ b/plugin/vim-oracle.vim
@@ -25,5 +25,5 @@ endif
 
 command! -nargs=0 VimOracle call vim_oracle#invoke()
 command! -nargs=1 VimOraclePrompt call vim_oracle#prompt_with_text(<q-args>)
-command! -nargs=0 VimOraclePromptWindow call vim_oracle#open_prompt_window()
+command! -nargs=0 -range VimOraclePromptWindow call vim_oracle#open_prompt_window()
 command! -nargs=0 VimOracleSend call vim_oracle#send_prompt_buffer()

--- a/plugin/vim-oracle.vim
+++ b/plugin/vim-oracle.vim
@@ -25,5 +25,6 @@ endif
 
 command! -nargs=0 VimOracle call vim_oracle#invoke()
 command! -nargs=1 VimOraclePrompt call vim_oracle#prompt_with_text(<q-args>)
-command! -nargs=0 -range VimOraclePromptWindow call vim_oracle#open_prompt_window()
+command! -nargs=0 -range VimOraclePromptWindow \
+            call vim_oracle#open_prompt_window(<line1>, <line2>, visualmode())
 command! -nargs=0 VimOracleSend call vim_oracle#send_prompt_buffer()

--- a/plugin/vim-oracle.vim
+++ b/plugin/vim-oracle.vim
@@ -26,5 +26,5 @@ endif
 command! -nargs=0 VimOracle call vim_oracle#invoke()
 command! -nargs=1 VimOraclePrompt call vim_oracle#prompt_with_text(<q-args>)
 command! -nargs=0 -range VimOraclePromptWindow \
-            call vim_oracle#open_prompt_window(visualmode())
+            call vim_oracle#open_prompt_window(<line1>, <line2>, visualmode())
 command! -nargs=0 VimOracleSend call vim_oracle#send_prompt_buffer()


### PR DESCRIPTION
## Summary
- respect visual mode when opening VimOraclePromptWindow
- insert a blank line at the end of the prompt for easier editing
- document requirement to run the command from Visual mode

## Testing
- `vim --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c5de45dc48329a61fab56b057225a